### PR TITLE
Fetch Pay Protocol URL Template From Server

### DIFF
--- a/src/currencyEngineTRD.js
+++ b/src/currencyEngineTRD.js
@@ -880,6 +880,30 @@ export class ShitcoinEngine {
     return (idx !== -1)
   }
 
+  async getPaymentProtocolInfo(url: string) {
+
+    let response = await io.fetch(url, {
+      headers: {
+        'Accept': 'application/payment-request',
+        'x-currency': 'DASH'
+      }
+    })
+
+    let body = await response.json()
+
+    return {
+      memo: body.memo,
+      nativeAmount: body.outputs.reduce((sum, o) => { return sum + o.amount }, 0).toString(),
+      spendTargets: body.outputs.map(output => {
+        return {
+          nativeAmount: output.amount.toString(),
+          publicAddress: output.address
+        }
+      })
+    }
+
+  }
+
   // asynchronous
   async makeSpend (abcSpendInfo:any) {
     // returns an ABCTransaction data structure, and checks for valid info


### PR DESCRIPTION
Specifies header `x-currency: DASH` to tell Anypay which coin to use.

WARNING: Upon checking out this repo I was unable to run `yarn lint` on it. Not sure if that was an issue with my local setup. Suspect because the repo hasn't received an update in 36 months. So I commented out the `lint` while I was developing.